### PR TITLE
Feature/change python module name

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,5 +7,5 @@ include_directories(
     ${OpenCV_INCLUDE_DIRS}
 )
 
-pybind11_add_module(pyORB16 pyORB16.cc)
-target_link_libraries(pyORB16 PRIVATE ORB16)
+pybind11_add_module(cv16 cv16.cc)
+target_link_libraries(cv16 PRIVATE ORB16)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,2 @@
+opencv_python
+termcolor

--- a/python/test_pyfast.py
+++ b/python/test_pyfast.py
@@ -1,13 +1,8 @@
-import pyORB16
+import cv16
 import cv2
 import numpy as np
-from termcolor import colored, cprint
-from test_pyorb import (zero_length_error, nonzero_length_error, none_error,
-                        notnone_error, neq_error, noninstance_error,
-                        normalize_minmax, pyorb_kpts_to_cv2_kpts,
-                        cv2_kpts_to_pyorb_kpts,
-                        test_detect, test_kpts_conversion)
-
+from test_utils import *
+from test_pyorb import test_detect, test_kpts_conversion
 
 
 if __name__ == "__main__":
@@ -15,7 +10,7 @@ if __name__ == "__main__":
     img16 = cv2.imread("assets/tir.png", -1)
     img8 = normalize_minmax(img16)
     mask16 = np.zeros(img16.shape, dtype=np.uint8)
-    fast16 = pyORB16.FastFeatureDetector16_create(threshold=40)
+    fast16 = cv16.FastFeatureDetector16_create(threshold=40)
 
     test_detect(fast16, img16, mask=mask16)
     kpts = test_detect(fast16, img16, mask=None)

--- a/python/test_pyorb.py
+++ b/python/test_pyorb.py
@@ -1,33 +1,7 @@
 import cv2
-import pyORB16
+import cv16
 import numpy as np
-from termcolor import colored, cprint
-
-def zero_length_error(name):
-    return colored("len({}) == 0".format(name), "red")
-
-def nonzero_length_error(name):
-    return colored("len({}) > 0".format(name), "red")
-
-def none_error(name):
-    return colored("{} is None".format(name), "red")
-
-def notnone_error(name):
-    return colored("{} is not None".format(name), "red")
-
-def neq_error(name1, name2):
-    return colored("{} != {}".format(name1, name2), "red")
-
-def noninstance_error(name, type):
-    return colored("{} is not {}".format(name, type), "red")
-
-def normalize_minmax(image):
-    min_value = image.min()
-    max_value = image.max()
-    image = image.astype(float)
-    image = (image - min_value) / (max_value - min_value)
-    image = (image * 255).astype("uint8")
-    return image
+from test_utils import *
     
 def pyorb_kpts_to_cv2_kpts(pyorb_kpts):
     cv2_kpts = []
@@ -43,8 +17,8 @@ def pyorb_kpts_to_cv2_kpts(pyorb_kpts):
 def cv2_kpts_to_pyorb_kpts(cv2_kpts):
     pyorb_kpts = []
     for cv2_kpt in cv2_kpts:
-        pyorb_kpt = pyORB16.KeyPoint()
-        pyorb_kpt.pt = pyORB16.Point2f(cv2_kpt.pt[0], cv2_kpt.pt[1])
+        pyorb_kpt = cv16.KeyPoint()
+        pyorb_kpt.pt = cv16.Point2f(cv2_kpt.pt[0], cv2_kpt.pt[1])
         pyorb_kpt.angle = cv2_kpt.angle
         pyorb_kpt.octave = cv2_kpt.octave
         pyorb_kpt.class_id = cv2_kpt.class_id
@@ -104,7 +78,7 @@ def test_kpts_conversion(pyorb_kpts):
 
     pyorb_kpts = cv2_kpts_to_pyorb_kpts(cv2_kpts)
     assert len(cv2_kpts) == len(pyorb_kpts), neq_error("len(kpts)", "len(pyorb_kpts)")
-    assert isinstance(pyorb_kpts[0], pyORB16.KeyPoint), noninstance_error("pyorb_kpts[0]", "pyORB16.KeyPoint")
+    assert isinstance(pyorb_kpts[0], cv16.KeyPoint), noninstance_error("pyorb_kpts[0]", "cv16.KeyPoint")
     
     cv2_kpts = pyorb_kpts_to_cv2_kpts(pyorb_kpts)
     assert len(cv2_kpts) == len(pyorb_kpts), neq_error("len(kpts)", "len(pyorb_kpts)")
@@ -115,11 +89,11 @@ def test_kpts_conversion(pyorb_kpts):
 
 
 if __name__ == "__main__":
-    ## test pyORB16 (16-bit version)
+    ## test cv16 (16-bit version)
     img16 = cv2.imread("assets/tir.png", -1)
     img8 = normalize_minmax(img16)
     mask16 = np.zeros(img16.shape, dtype=np.uint8)
-    orb16 = pyORB16.ORB16_create(nfeatures=2000, fastThreshold=40)
+    orb16 = cv16.ORB16_create(nfeatures=2000, fastThreshold=40)
 
     test_detect_and_compute(orb16, img16, mask=mask16)
     kpts, descs = test_detect_and_compute(orb16, img16, mask=None)
@@ -157,26 +131,29 @@ if __name__ == "__main__":
             text += ", fastThr=" + str(fast_thr)
         return text
 
-    orb16_20 = pyORB16.ORB16_create(nfeatures=2000, fastThreshold=20)
-    orb16_40 = pyORB16.ORB16_create(nfeatures=2000, fastThreshold=40)
+    orb16_20 = cv16.ORB16_create(nfeatures=2000, fastThreshold=20)
+    orb16_40 = cv16.ORB16_create(nfeatures=2000, fastThreshold=40)
     orb8_20 = cv2.ORB_create(nfeatures=2000, fastThreshold=20)
 
     kpts16_20 = orb16_20.detect(img16, None)
     cv2_kpts16_20 = pyorb_kpts_to_cv2_kpts(kpts16_20)
     kpts16_20_num = len(kpts16_20)
     img16_20_kpts = drawKeypoints(img8, cv2_kpts16_20)
-    cv2.putText(img16_20_kpts, getText(16, kpts16_20_num, 20), (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
+    cv2.putText(img16_20_kpts, getText(16, kpts16_20_num, 20), (10, 30), 
+                cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
 
     kpts16_40 = orb16_40.detect(img16, None)
     cv2_kpts16_40 = pyorb_kpts_to_cv2_kpts(kpts16_40)
     kpts16_40_num = len(kpts16_40)
     img16_40_kpts = drawKeypoints(img8, cv2_kpts16_40)
-    cv2.putText(img16_40_kpts, getText(16, kpts16_40_num, 40), (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
+    cv2.putText(img16_40_kpts, getText(16, kpts16_40_num, 40), (10, 30), 
+                cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
 
     kpts8 = orb8.detect(img8, None)
     kpts8_num = len(kpts8)
     img8_kpts = drawKeypoints(img8, kpts8)
-    cv2.putText(img8_kpts, getText(8, kpts8_num), (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
+    cv2.putText(img8_kpts, getText(8, kpts8_num), (10, 30), 
+                cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
 
     concat = cv2.hconcat([img16_20_kpts, img16_40_kpts, img8_kpts])
     cv2.imshow("keypoints", concat)

--- a/python/test_utils.py
+++ b/python/test_utils.py
@@ -1,0 +1,30 @@
+import cv2
+import cv16
+import numpy as np
+from termcolor import colored, cprint
+
+def zero_length_error(name):
+    return colored("len({}) == 0".format(name), "red")
+
+def nonzero_length_error(name):
+    return colored("len({}) > 0".format(name), "red")
+
+def none_error(name):
+    return colored("{} is None".format(name), "red")
+
+def notnone_error(name):
+    return colored("{} is not None".format(name), "red")
+
+def neq_error(name1, name2):
+    return colored("{} != {}".format(name1, name2), "red")
+
+def noninstance_error(name, type):
+    return colored("{} is not {}".format(name, type), "red")
+
+def normalize_minmax(image):
+    min_value = image.min()
+    max_value = image.max()
+    image = image.astype(float)
+    image = (image - min_value) / (max_value - min_value)
+    image = (image * 255).astype("uint8")
+    return image

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ import shutil
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
+# parse requirements.txt in python folder
+root = Path(__file__).parent
+with open(str(root / 'python' / 'requirements.txt'), 'r') as f:
+    dependencies = f.read().split('\n')
+
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
     "win32": "Win32",
@@ -153,6 +158,7 @@ setup(
     author_email="now9728@gmail.com",
     description="Pybind wrapper for 16-bit ORB feature",
     long_description="",
+    install_requires=dependencies,
     ext_modules=[CMakeExtension("cv16")],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -147,13 +147,13 @@ class CMakeBuild(build_ext):
 # The information here can also be placed in setup.cfg - better separation of
 # logic and declaration, and simpler if you include description/version in a file.
 setup(
-    name="pyORB16",
+    name="cv16",
     version="0.0.0",
     author="Hyeonjae Gil",
     author_email="now9728@gmail.com",
     description="Pybind wrapper for 16-bit ORB feature",
     long_description="",
-    ext_modules=[CMakeExtension("pyORB16")],
+    ext_modules=[CMakeExtension("cv16")],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
     python_requires=">=3.7",


### PR DESCRIPTION
change python module name from **pyORB16** to **cv16** for the following reasons:
- pyORB16 is named specifically for ORB
- but this module supports FAST corner and Canny edge detection
- More utils for 16bit image will be added soon 